### PR TITLE
JUCX: add exceptions to be thrown by progress and errorHandler.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -95,12 +95,6 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
             data.put(0, (byte)1);
         }
 
-        ByteBuffer sendBuffer = ByteBuffer.allocateDirect(100);
-        sendBuffer.asCharBuffer().put("DONE");
-        
-        UcpRequest sent = endpoint.sendTaggedNonBlocking(sendBuffer, null);
-        worker.progressRequest(sent);
-
         UcpRequest closeRequest = endpoint.closeNonBlockingFlush();
         worker.progressRequest(closeRequest);
         // Close request won't be return to pull automatically, since there's no callback.

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
@@ -5,13 +5,11 @@
 
 package org.openucx.jucx.examples;
 
-import org.openucx.jucx.UcxCallback;
-import org.openucx.jucx.ucp.UcpRequest;
+import org.openucx.jucx.UcxException;
+import org.openucx.jucx.ucp.*;
 import org.openucx.jucx.UcxUtils;
-import org.openucx.jucx.ucp.UcpEndpoint;
-import org.openucx.jucx.ucp.UcpEndpointParams;
-import org.openucx.jucx.ucp.UcpMemory;
 
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
@@ -28,6 +26,13 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
         String serverHost = argsMap.get("s");
         UcpEndpoint endpoint = worker.newEndpoint(new UcpEndpointParams()
             .setPeerErrorHandlingMode()
+            .setErrorHandler((ep, status, errorMsg) -> {
+                if (status == -25) {
+                    throw new ConnectException(errorMsg);
+                } else {
+                    throw new UcxException(errorMsg);
+                }
+            })
             .setSocketAddress(new InetSocketAddress(serverHost, serverPort)));
 
         UcpMemory memory = context.memoryMap(allocationParams);
@@ -49,22 +54,21 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
 
         // Send memory metadata and wait until receiver will finish benchmark.
         endpoint.sendTaggedNonBlocking(sendData, null);
-        ByteBuffer recvBuffer = ByteBuffer.allocateDirect(4096);
-        UcpRequest recvRequest = worker.recvTaggedNonBlocking(recvBuffer,
-            new UcxCallback() {
-                @Override
-                public void onSuccess(UcpRequest request) {
-                    System.out.println("Received a message:");
-                    System.out.println(recvBuffer.asCharBuffer().toString().trim());
-                }
-            });
 
-        worker.progressRequest(recvRequest);
+        try {
+            while (worker.progress() == 0) {
+                worker.waitForEvents();
+            }
+        } catch (ConnectException ex) {
 
-        UcpRequest closeRequest = endpoint.closeNonBlockingFlush();
-        worker.progressRequest(closeRequest);
-        resources.push(closeRequest);
+        } catch (Exception ex) {
+            System.err.println(ex.getMessage());
+        } finally {
+            UcpRequest closeRequest = endpoint.closeNonBlockingForce();
+            worker.progressRequest(closeRequest);
+            resources.push(closeRequest);
 
-        closeResources();
+            closeResources();
+        }
     }
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointErrorHandler.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpointErrorHandler.java
@@ -15,5 +15,5 @@ public interface UcpEndpointErrorHandler {
      *             all subsequent operations on this ep will fail with
      *             the error code passed in {@code status}.
      */
-    void onError(UcpEndpoint ep, int status, String errorMsg);
+    void onError(UcpEndpoint ep, int status, String errorMsg) throws Exception;
 }

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -59,14 +59,14 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
      * This routine explicitly progresses all communication operations on a worker.
      * @return Non-zero if any communication was progressed, zero otherwise.
      */
-    public int progress() {
+    public int progress() throws Exception {
         return progressWorkerNative(getNativeId());
     }
 
     /**
      * Blocking progress for request until it's not completed.
      */
-    public void progressRequest(UcpRequest request) {
+    public void progressRequest(UcpRequest request) throws Exception {
         while (!request.isCompleted()) {
             progress();
         }
@@ -251,7 +251,7 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
 
     private static native void releaseAddressNative(long workerId, ByteBuffer addressId);
 
-    private static native int progressWorkerNative(long workerId);
+    private static native int progressWorkerNative(long workerId) throws Exception;
 
     private static native UcpRequest flushNonBlockingNative(long workerId, UcxCallback callback);
 

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -31,7 +31,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testGetNB() {
+    public void testGetNB() throws Exception {
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestRmaFeature();
         UcpWorkerParams rdmaWorkerParams = new UcpWorkerParams().requestWakeupRMA();
@@ -102,7 +102,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testPutNB() {
+    public void testPutNB() throws Exception {
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestRmaFeature();
         UcpWorkerParams rdmaWorkerParams = new UcpWorkerParams().requestWakeupRMA();
@@ -186,7 +186,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testRecvAfterSend() {
+    public void testRecvAfterSend() throws Exception {
         long sendTag = 4L;
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestRmaFeature().requestTagFeature()
@@ -211,8 +211,13 @@ public class UcpEndpointTest extends UcxTest {
             @Override
             public void run() {
                 while (!isInterrupted()) {
-                    worker1.progress();
-                    worker2.progress();
+                    try {
+                        worker1.progress();
+                        worker2.progress();
+                    } catch (Exception ex) {
+                        System.err.println(ex.getMessage());
+                        ex.printStackTrace();
+                    }
                 }
             }
         };
@@ -263,7 +268,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testBufferOffset() {
+    public void testBufferOffset() throws Exception {
         int msgSize = 200;
         int offset = 100;
         // Crerate 2 contexts + 2 workers
@@ -311,7 +316,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testFlushEp() {
+    public void testFlushEp() throws Exception {
         int numRequests = 10;
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestRmaFeature();
@@ -356,7 +361,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testRecvSize() {
+    public void testRecvSize() throws Exception {
         UcpContext context1 = new UcpContext(new UcpParams().requestTagFeature());
         UcpContext context2 = new UcpContext(new UcpParams().requestTagFeature());
 
@@ -386,7 +391,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testStreamingAPI() {
+    public void testStreamingAPI() throws Exception {
         UcpParams params = new UcpParams().requestStreamFeature().requestRmaFeature();
         UcpContext context1 = new UcpContext(params);
         UcpContext context2 = new UcpContext(params);
@@ -537,7 +542,7 @@ public class UcpEndpointTest extends UcxTest {
     }
 
     @Test
-    public void testEpErrorHandler() {
+    public void testEpErrorHandler() throws Exception {
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestTagFeature();
         UcpWorkerParams workerParams = new UcpWorkerParams();

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -86,7 +86,7 @@ public class UcpListenerTest  extends UcxTest {
     }
 
     @Test
-    public void testConnectionHandler() {
+    public void testConnectionHandler() throws Exception {
         UcpContext context1 = new UcpContext(new UcpParams().requestStreamFeature()
             .requestRmaFeature());
         UcpContext context2 = new UcpContext(new UcpParams().requestStreamFeature()

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpRequestTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpRequestTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 
 public class UcpRequestTest {
     @Test
-    public void testCancelRequest() {
+    public void testCancelRequest() throws Exception {
         UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
         UcpWorker worker = context.newWorker(new UcpWorkerParams());
         UcpRequest recv = worker.recvTaggedNonBlocking(ByteBuffer.allocateDirect(100), null);

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpWorkerTest.java
@@ -19,7 +19,7 @@ public class UcpWorkerTest extends UcxTest {
     private static int numWorkers = Runtime.getRuntime().availableProcessors();
 
     @Test
-    public void testSingleWorker() {
+    public void testSingleWorker() throws Exception {
         UcpContext context = new UcpContext(new UcpParams().requestTagFeature());
         assertEquals(2, UcsConstants.ThreadMode.UCS_THREAD_MODE_MULTI);
         assertNotEquals(context.getNativeId(), null);
@@ -99,8 +99,12 @@ public class UcpWorkerTest extends UcxTest {
             @Override
             public void run() {
                 while (!isInterrupted()) {
-                    if (worker.progress() == 0) {
-                        worker.waitForEvents();
+                    try {
+                        if (worker.progress() == 0) {
+                            worker.waitForEvents();
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
                     }
                 }
                 success.set(true);
@@ -120,7 +124,7 @@ public class UcpWorkerTest extends UcxTest {
     }
 
     @Test
-    public void testFlushWorker() {
+    public void testFlushWorker() throws Exception {
         int numRequests = 10;
         // Crerate 2 contexts + 2 workers
         UcpParams params = new UcpParams().requestRmaFeature();
@@ -166,7 +170,7 @@ public class UcpWorkerTest extends UcxTest {
     }
 
     @Test
-    public void testTagProbe() {
+    public void testTagProbe() throws Exception {
         UcpParams params = new UcpParams().requestTagFeature();
         UcpContext context1 = new UcpContext(params);
         UcpContext context2 = new UcpContext(params);


### PR DESCRIPTION
## What
Add exception to `progress` and errorHandler methods signature.

## Why ?
To catch and rethrow different errors. To fix client - server example with a new setting.
