### PR TITLE
JUCX: add status codes to easilly handle error types.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkReceiver.java
@@ -42,14 +42,6 @@ public class UcxReadBWBenchmarkReceiver extends UcxBenchmark {
             .setConnectionRequest(connRequest.get())
             .setPeerErrorHandlingMode());
 
-        // Temporary workaround until new connection establishment protocol in UCX.
-        for (int i = 0; i < 10; i++) {
-            worker.progress();
-            try {
-                Thread.sleep(10);
-            } catch (Exception ignored) { }
-        }
-
         ByteBuffer recvBuffer = ByteBuffer.allocateDirect(4096);
         UcpRequest recvRequest = worker.recvTaggedNonBlocking(recvBuffer, null);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/examples/UcxReadBWBenchmarkSender.java
@@ -8,6 +8,7 @@ package org.openucx.jucx.examples;
 import org.openucx.jucx.UcxException;
 import org.openucx.jucx.ucp.*;
 import org.openucx.jucx.UcxUtils;
+import org.openucx.jucx.ucs.UcsConstants;
 
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
@@ -27,7 +28,7 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
         UcpEndpoint endpoint = worker.newEndpoint(new UcpEndpointParams()
             .setPeerErrorHandlingMode()
             .setErrorHandler((ep, status, errorMsg) -> {
-                if (status == -25) {
+                if (status == UcsConstants.STATUS.UCS_ERR_CONNECTION_RESET.value) {
                     throw new ConnectException(errorMsg);
                 } else {
                     throw new UcxException(errorMsg);
@@ -56,8 +57,10 @@ public class UcxReadBWBenchmarkSender extends UcxBenchmark {
         endpoint.sendTaggedNonBlocking(sendData, null);
 
         try {
-            while (worker.progress() == 0) {
-                worker.waitForEvents();
+            while (true) {
+                while (worker.progress() == 0) {
+                    worker.waitForEvents();
+                }
             }
         } catch (ConnectException ex) {
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucs/UcsConstants.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucs/UcsConstants.java
@@ -22,6 +22,58 @@ public class UcsConstants {
         public static int UCS_THREAD_MODE_MULTI;
     }
 
+    /**
+     * Status codes
+     */
+    public enum STATUS {
+        /* Operation completed successfully */
+        UCS_OK                        (0),
+
+        /* Operation is queued and still in progress */
+        UCS_INPROGRESS                (1),
+
+        /* Failure codes */
+        UCS_ERR_NO_MESSAGE            (-1),
+        UCS_ERR_NO_RESOURCE           (-2),
+        UCS_ERR_IO_ERROR              (-3),
+        UCS_ERR_NO_MEMORY             (-4),
+        UCS_ERR_INVALID_PARAM         (-5),
+        UCS_ERR_UNREACHABLE           (-6),
+        UCS_ERR_INVALID_ADDR          (-7),
+        UCS_ERR_NOT_IMPLEMENTED       (-8),
+        UCS_ERR_MESSAGE_TRUNCATED     (-9),
+        UCS_ERR_NO_PROGRESS           (-10),
+        UCS_ERR_BUFFER_TOO_SMALL      (-11),
+        UCS_ERR_NO_ELEM               (-12),
+        UCS_ERR_SOME_CONNECTS_FAILED  (-13),
+        UCS_ERR_NO_DEVICE             (-14),
+        UCS_ERR_BUSY                  (-15),
+        UCS_ERR_CANCELED              (-16),
+        UCS_ERR_SHMEM_SEGMENT         (-17),
+        UCS_ERR_ALREADY_EXISTS        (-18),
+        UCS_ERR_OUT_OF_RANGE          (-19),
+        UCS_ERR_TIMED_OUT             (-20),
+        UCS_ERR_EXCEEDS_LIMIT         (-21),
+        UCS_ERR_UNSUPPORTED           (-22),
+        UCS_ERR_REJECTED              (-23),
+        UCS_ERR_NOT_CONNECTED         (-24),
+        UCS_ERR_CONNECTION_RESET      (-25),
+
+        UCS_ERR_FIRST_LINK_FAILURE    (-40),
+        UCS_ERR_LAST_LINK_FAILURE     (-59),
+        UCS_ERR_FIRST_ENDPOINT_FAILURE(-60),
+        UCS_ERR_ENDPOINT_TIMEOUT      (-80),
+        UCS_ERR_LAST_ENDPOINT_FAILURE (-89),
+
+        UCS_ERR_LAST                  (-100);
+
+        public final int value;
+
+        STATUS(int value) {
+            this.value = value;
+        }
+    }
+
     private static void load() {
         NativeLibs.load();
         loadConstants();

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -113,7 +113,7 @@ public class UcpListenerTest  extends UcxTest {
         // Create endpoint from another worker from pool.
         UcpEndpoint serverToClient = serverWorker2.newEndpoint(
             new UcpEndpointParams().setConnectionRequest(conRequest.get()));
-        
+
         // Temporary workaround until new connection establishment protocol in UCX.
         for (int i = 0; i < 10; i++) {
             serverWorker1.progress();
@@ -147,8 +147,16 @@ public class UcpListenerTest  extends UcxTest {
 
         assertEquals(UcpMemoryTest.MEM_SIZE, recv.getRecvSize());
 
+        UcpRequest serverClose = serverToClient.closeNonBlockingFlush();
+        UcpRequest clientClose = clientToServer.closeNonBlockingFlush();
+
+        while (!serverClose.isCompleted() || !clientClose.isCompleted()) {
+            serverWorker2.progress();
+            clientWorker.progress();
+        }
+
         Collections.addAll(resources, context2, context1, clientWorker, serverWorker1,
-            serverWorker2, listener, serverToClient, clientToServer);
+            serverWorker2, listener);
         closeResources();
     }
 }


### PR DESCRIPTION
## What
 add status codes to easilly handle error types.

## Why ?
Just hardcode enums with status, to not set them from C layer, since there's too much statuses, and that's a stabe codes.